### PR TITLE
Avoid issues when object number reaches 2^16

### DIFF
--- a/tagpdf-backend.dtx
+++ b/tagpdf-backend.dtx
@@ -705,7 +705,7 @@ end
 %    \begin{macrocode}
 local function @@_pdf_object_ref (name)
    local tokenname = 'c__pdf_backend_object_'..name..'_int'
-   local object = token.create(tokenname).index..' 0 R'
+   local object = token.create(tokenname).mode ..' 0 R'
    return object
 end
 ltx.@@.func.pdf_object_ref=@@_pdf_object_ref


### PR DESCRIPTION
Fixes #97.

LuaTeX's `.index` is primarily intended to support getting the index of a register and is therefore hardcoded to never return values bigger than a valid register index. Since expl3 integers in this range do not correspond to register indices but are chardefs, we can use `.mode` to avoid this restriction.