### PR TITLE
Add helpers to avoid use of tagpdf internals in latex-lab

### DIFF
--- a/tagpdf-roles.dtx
+++ b/tagpdf-roles.dtx
@@ -1389,6 +1389,19 @@
    , mathml-tags .bool_gset:N = \g_@@_role_add_mathml_bool
    , add-new-tag .meta:n = {role/new-tag={#1}}
   }
+%    \end{macrocode}
+% \end{macro}
+% \begin{function}[TF]{\@@_if_tag_known:n}
+%  \begin{syntax}
+%   \cs{@@_if_tag_known:nTF} \Arg{tag} \Arg{true code} \Arg{false code}
+%  \end{syntax}
+% \end{function}
+% \begin{macro}[TF]{\@@_if_tag_known:n}
+%    \begin{macrocode}
+\prg_new_protected_conditional:Nnn \@@_if_tag_known:n { T, F, TF }
+  {
+    \prop_get:NnNTF\g_@@_role_tags_NS_prop{#1}\l_@@_tmp_unused_tl { \prg_return_true: } { \prg_return_false: }
+  }
 %</package>
 %    \end{macrocode}
 % \end{macro}

--- a/tagpdf-roles.dtx
+++ b/tagpdf-roles.dtx
@@ -92,6 +92,12 @@
 % This checks if the tag \meta{tag} from the name space \meta{namespace}
 % can be used at the current position. In tagpdf-base it is always true.
 % \end{function}
+% \begin{function}[TF]{\tag_if_tag_known:n}
+%  \begin{syntax}
+%   \cs{tag_if_tag_known:nTF} \Arg{tag} \Arg{true code} \Arg{false code}
+%  \end{syntax}
+% Check if a specified structure tag has been declared in the current document.
+% \end{function}
 % \end{documentation}
 % \begin{implementation}
 %    \begin{macrocode}
@@ -1391,14 +1397,9 @@
   }
 %    \end{macrocode}
 % \end{macro}
-% \begin{function}[TF]{\@@_if_tag_known:n}
-%  \begin{syntax}
-%   \cs{@@_if_tag_known:nTF} \Arg{tag} \Arg{true code} \Arg{false code}
-%  \end{syntax}
-% \end{function}
-% \begin{macro}[TF]{\@@_if_tag_known:n}
+% \begin{macro}[TF]{\tag_if_tag_known:n}
 %    \begin{macrocode}
-\prg_new_protected_conditional:Nnn \@@_if_tag_known:n { T, F, TF }
+\prg_new_protected_conditional:Nnn \tag_if_tag_known:n { T, F, TF }
   {
     \prop_get:NnNTF\g_@@_role_tags_NS_prop{#1}\l_@@_tmp_unused_tl { \prg_return_true: } { \prg_return_false: }
   }

--- a/tagpdf-struct.dtx
+++ b/tagpdf-struct.dtx
@@ -2671,7 +2671,23 @@
          }
     },
   }
-%</package>
 %    \end{macrocode}
 % \end{structkeydecl}
+% \begin{function}{\@@_struct_get_current_tag:N}
+%   \begin{syntax}
+%     \cs{@@_struct_get_current_tag:N} \Arg{tl-var}
+%   \end{syntax}
+%  Get the currently active structure tag. The \Arg{tl-var} get assigned
+%  two brace groups containing the current structure tag and the role-mapped
+%  current structure tag.
+% \end{function}
+% \begin{macro}{\@@_struct_get_current_tag:N}
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_struct_get_current_tag:N
+  {
+    \seq_get:NN \g_@@_struct_tag_stack_seq
+  }
+%</package>
+%    \end{macrocode}
+% \end{macro}
 % \end{implementation}

--- a/tagpdf-struct.dtx
+++ b/tagpdf-struct.dtx
@@ -302,9 +302,9 @@
 % to add associated files to the root structure. Like |AF| it can be used more than
 % once to add more than one file.
 % \end{setupkeydecl}
-% \begin{function}{\tag_struct_get_current_tag:N}
+% \begin{function}{\tag_struct_get_current_name:N}
 %   \begin{syntax}
-%     \cs{tag_struct_get_current_tag:N} \Arg{tl-var}
+%     \cs{tag_struct_get_current_name:N} \Arg{tl-var}
 %   \end{syntax}
 %  Get the currently active structure tag. The \Arg{tl-var} get assigned
 %  two brace groups containing the current structure tag and the role-mapped
@@ -2681,9 +2681,9 @@
   }
 %    \end{macrocode}
 % \end{structkeydecl}
-% \begin{macro}{\tag_struct_get_current_tag:N}
+% \begin{macro}{\tag_struct_get_current_name:N}
 %    \begin{macrocode}
-\cs_new_protected:Npn \tag_struct_get_current_tag:N
+\cs_new_protected:Npn \tag_struct_get_current_name:N
   {
     \seq_get:NN \g_@@_struct_tag_stack_seq
   }

--- a/tagpdf-struct.dtx
+++ b/tagpdf-struct.dtx
@@ -302,6 +302,14 @@
 % to add associated files to the root structure. Like |AF| it can be used more than
 % once to add more than one file.
 % \end{setupkeydecl}
+% \begin{function}{\tag_struct_get_current_tag:N}
+%   \begin{syntax}
+%     \cs{tag_struct_get_current_tag:N} \Arg{tl-var}
+%   \end{syntax}
+%  Get the currently active structure tag. The \Arg{tl-var} get assigned
+%  two brace groups containing the current structure tag and the role-mapped
+%  current structure tag.
+% \end{function}
 % \end{documentation}
 % \begin{implementation}
 %    \begin{macrocode}
@@ -2673,17 +2681,9 @@
   }
 %    \end{macrocode}
 % \end{structkeydecl}
-% \begin{function}{\@@_struct_get_current_tag:N}
-%   \begin{syntax}
-%     \cs{@@_struct_get_current_tag:N} \Arg{tl-var}
-%   \end{syntax}
-%  Get the currently active structure tag. The \Arg{tl-var} get assigned
-%  two brace groups containing the current structure tag and the role-mapped
-%  current structure tag.
-% \end{function}
-% \begin{macro}{\@@_struct_get_current_tag:N}
+% \begin{macro}{\tag_struct_get_current_tag:N}
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_struct_get_current_tag:N
+\cs_new_protected:Npn \tag_struct_get_current_tag:N
   {
     \seq_get:NN \g_@@_struct_tag_stack_seq
   }


### PR DESCRIPTION
Currently in some places latex-lab directly accesses `\g_@@_role_tags_NS_prop` and `\g_@@_struct_tag_stack_seq`. This makes latex-lab bound very closely to implementation details of tagpdf. Add two helpers to abstract this a bit more.