### PR TITLE
Remove additional comma from data file

### DIFF
--- a/tagpdf-data.dtx
+++ b/tagpdf-data.dtx
@@ -146,7 +146,7 @@ RT,RT,pdf,I,
 Warichu,Warichu,pdf,I,
 WT,WT,pdf,I,
 WP,WP,pdf,I,
-Art,Art,pdf,,G,  % only pdf, types unclear, needs correction later       
+Art,Art,pdf,G,  % only pdf, types unclear, needs correction later       
 BlockQuote,BlockQuote,pdf,G, %or GB?
 TOC,TOC,pdf,G,        
 TOCI,TOCI,pdf,G,       

--- a/testfiles-pdftex/show-variables-17.tlg
+++ b/testfiles-pdftex/show-variables-17.tlg
@@ -328,7 +328,7 @@ The property list \g__tag_role_tags_class_prop contains the pairs (without outer
 >  {Warichu}  =>  {I}
 >  {WT}  =>  {I}
 >  {WP}  =>  {I}
->  {Art}  =>  {--UNKNOWN--}
+>  {Art}  =>  {G}
 >  {BlockQuote}  =>  {G}
 >  {TOC}  =>  {G}
 >  {TOCI}  =>  {G}

--- a/testfiles-pdftex/show-variables-20.tlg
+++ b/testfiles-pdftex/show-variables-20.tlg
@@ -998,7 +998,7 @@ The property list \g__tag_role_NS_pdf_class_prop contains the pairs (without out
 >  {Warichu}  =>  {I}
 >  {WT}  =>  {I}
 >  {WP}  =>  {I}
->  {Art}  =>  {--UNKNOWN--}
+>  {Art}  =>  {G}
 >  {BlockQuote}  =>  {G}
 >  {TOC}  =>  {G}
 >  {TOCI}  =>  {G}
@@ -1010,7 +1010,7 @@ The property list \g__tag_role_NS_pdf_class_prop contains the pairs (without out
 >  {Reference}  =>  {B}
 >  {BibEntry}  =>  {B}
 >  {Code}  =>  {I}
->  {DocumentFragment}  =>  {--UNKNOWN--}
+>  {DocumentFragment}  =>  {G}
 >  {Aside}  =>  {GBI}
 >  {H7}  =>  {B}
 >  {H8}  =>  {B}


### PR DESCRIPTION
In `tagpdf-ns-pdf.def` the entry for `Art` has an additional comma compared to all other fields. Based on the comment after it I'm not sure if that is intentional, but it looks like a typo.